### PR TITLE
Correct test's usage of non-square nested arrays

### DIFF
--- a/session3/spec/5.rb
+++ b/session3/spec/5.rb
@@ -22,9 +22,8 @@ describe 'spiral_access' do
     should_see [[1,2],[4,3]], [1,2,3,4]
   end
   
-  
-  it 'should yield 1,2,3,4,5,6 when given [[1,2,3],[8,9,4],[7,6,5]]' do
-    should_see [[1,2,3],[6,5,4]], [1,2,3,4,5,6]
+  it 'should yield 1,2,3,4,5,6,7,8,9 when given [[1,2,3],[8,9,4],[7,6,5]]' do
+    should_see [[1,2,3], [8,9,4], [7,6,5]], [1,2,3,4,5,6,7,8,9]
   end
     
   it 'should fit the example given in the notes' do


### PR DESCRIPTION
This resolves an apparent discrepancy between the 'it' description and the actual test code. Another option would be to just change the 'it' description but since the comments in `session3/challenge/5_blocks.rb` specify that `spiral_access` takes 2d array that is square, I assume the tests should reflect this usage.

If, on the other hand, you'd like `spiral_access` to handle all 2d arrays (e.g. other rectangles), perhaps there should be a couple tests to make that explicit.

P.S. Thank you so much for creating Ruby Kickstart. It's been a while since I've gone through it much, but when I was starting to learn Ruby, it helped me sooooo much!
